### PR TITLE
Implement iOS stretching fix

### DIFF
--- a/src/image-zoom.ios.ts
+++ b/src/image-zoom.ios.ts
@@ -21,6 +21,7 @@ export class ImageZoom extends ImageZoomBase {
     public createNativeView() {
         this._image = UIImageView.new();
         this._image.clipsToBounds = true;
+        this._image.contentMode = UIViewContentMode.ScaleAspectFit;
         const nativeView = UIScrollView.new();
         nativeView.addSubview(this._image);
         nativeView.zoomScale = this.zoomScale;


### PR DESCRIPTION
Following solution suggestion here:
https://github.com/triniwiz/nativescript-image-zoom/issues/16#issuecomment-459957691

Verified manually applied fix worked in iOS simulator, then forked and submitted PR.

Both these issues are relating to scaling on iOS: 

- https://github.com/triniwiz/nativescript-image-zoom/issues/16
- https://github.com/triniwiz/nativescript-image-zoom/issues/13