### PR TITLE
Fix for setting source as android ImageSource

### DIFF
--- a/src/image-zoom.android.ts
+++ b/src/image-zoom.android.ts
@@ -56,13 +56,7 @@ export class ImageZoom extends ImageZoomBase {
         );
         if (this.src) {
             const image = this.getImage(this.src);
-            if (this.src.startsWith('res://')) {
-                if (+image > 0) {
-                    this.builder = this.picasso.load(image);
-                }
-            } else {
-                this.builder = this.picasso.load(image);
-            }
+            this.builder = this.picasso.load(image);
         }
         if (this.stretch) {
             this.resetImage();
@@ -147,13 +141,7 @@ export class ImageZoom extends ImageZoomBase {
     [srcProperty.setNative](src: any) {
         if (!this.builder) {
             const image = this.getImage(src);
-            if (types.isString(src) && this.src.startsWith('res://')) {
-                if (+image > 0) {
-                    this.builder = this.picasso.load(image);
-                }
-            } else {
-                this.builder = this.picasso.load(image);
-            }
+            this.builder = this.picasso.load(image);
         }
         if (this.stretch) {
             this.resetImage();


### PR DESCRIPTION
When attempting to init the view with ImageSource (passing as argument into <b>src</b> field), actually anything rather a string, it would stumble upon string check for path. While that check is redundant, and actually has happened in <b>getImage</b> function.